### PR TITLE
Extern MINIHDLC_MAX_FRAME_LENGTH as const uint16

### DIFF
--- a/minihdlc.h
+++ b/minihdlc.h
@@ -8,7 +8,7 @@ typedef void (*sendchar_type)(uint8_t data);
 typedef void (*frame_handler_type)(const uint8_t *frame_buffer,
 		uint16_t frame_length);
 
-#define MINIHDLC_MAX_FRAME_LENGTH 64
+extern const uint16_t MINIHDLC_MAX_FRAME_LENGTH;
 
 void minihdlc_init(sendchar_type sendchar_function,
 		frame_handler_type frame_hander_function);


### PR DESCRIPTION
The user of this library can now define the size of the frame buffer
in there target file instead of always using a fixed buffer of 64.