### PR TITLE
Avoids underflow in minihdlc_char_receiver

### DIFF
--- a/minihdlc.c
+++ b/minihdlc.c
@@ -95,7 +95,7 @@ void minihdlc_char_receiver(uint8_t data) {
 
 	mhst.receive_frame_buffer[mhst.frame_position] = data;
 
-	if (mhst.frame_position - 2 >= 0) {
+	if (mhst.frame_position >= 2) {
 		mhst.frame_checksum = _crc_ccitt_update(mhst.frame_checksum,
 				mhst.receive_frame_buffer[mhst.frame_position - 2]);
 	}


### PR DESCRIPTION
Avoids underflow in minihdlc_char_receiver by checking against `2` directly. This underflow may occur depending on compilers or compiler flags.